### PR TITLE
Add formula for Blightmud

### DIFF
--- a/Formula/blightmud.rb
+++ b/Formula/blightmud.rb
@@ -1,0 +1,17 @@
+class Blightmud < Formula
+  desc "Terminal mud client written in Rust"
+  homepage "https://github.com/LiquidityC/Blightmud"
+  url "https://github.com/LiquidityC/Blightmud/archive/v1.0.0.tar.gz"
+  sha256 "76ce6df25dfff1d7d7c5c5027e260e9a0209d1475347b7a036e34047af493760"
+  license "GPL-3.0-only"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    system bin/"blightmud", "-h"
+  end
+end


### PR DESCRIPTION
As discussed in https://github.com/LiquidityC/Blightmud/issues/49 here is the formula to install blightmud from source. Once we have automated mac builds set up we can update this formula to install the precomiled binaries instead.