### PR TITLE
Change to do a binary install

### DIFF
--- a/Formula/blightmud.rb
+++ b/Formula/blightmud.rb
@@ -1,14 +1,15 @@
 class Blightmud < Formula
   desc "Terminal mud client written in Rust"
   homepage "https://github.com/LiquidityC/Blightmud"
-  url "https://github.com/LiquidityC/Blightmud/archive/v2.0.0.tar.gz"
-  sha256 "0fdda39c8b9524031cf0098211354fa62bb89a5d8af2af64f213fb4cac0d25d5"
+  version "2.0.0"
   license "GPL-3.0-only"
+  bottle :unneeded
 
-  depends_on "rust" => :build
+  url "https://github.com/LiquidityC/Blightmud/releases/download/v#{version}/blightmud-v#{version}-macos.zip"
+  sha256 "cdc2bb38e593d16793c3bff5c7df6c80ada38390cfcca3d9ec3d2237f65dfe5e"
 
   def install
-    system "cargo", "install", *std_cargo_args
+    bin.install "blightmud"
   end
 
   test do


### PR DESCRIPTION
Update the blightmud formula to install the pre-compiled binary from the main repository instead of installing from source.

@LiquidityC if you want to support Linuxbrew as well, I will need the linux release as *.tar.gz or *.zip file in addition to the current *.deb asset.﻿